### PR TITLE
Append string classnames from extra attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ Equivalent output:
 ```
 
 
+### Classes
+
+There's a shortcut for dynamic classes: strings or iterables of classnames are automatically appended to the sugared classname!
+
+```python
+render(['.foo', {'class': 'bar baz'}])
+# u'<div class="foo bar baz"></div>'
+
+render(['.foo', {'class': ['bar', 'baz']}])
+# u'<div class="foo bar baz"></div>'
+```
+
+
 ### Installation
 
     pip install cottonmouth

--- a/cottonmouth/html.py
+++ b/cottonmouth/html.py
@@ -3,9 +3,6 @@ import itertools
 
 from . import constants
 
-CLASS_NAME_COLLISION_MESSAGE = \
-    u'Class names must be set in the tag or the attribute, not both.'
-
 
 def render(*content, **context):
     """

--- a/cottonmouth/html.py
+++ b/cottonmouth/html.py
@@ -71,11 +71,13 @@ def render_tag(tag, content, **context):
         # If there is no remainder, we just render the tag
         extra, remainder = {}, []
     except TypeError:
-        # If the
+        # There are no extra attributes
         extra, remainder = {}, content
 
     # Default to div if no explicit tag is provided
     if tag.startswith(u'#'):
+        tag = u'div{}'.format(tag)
+    elif tag.startswith(u'.'):
         tag = u'div{}'.format(tag)
 
     # Split tag into ["tag#id", "class1", "class2", ...] chunks

--- a/cottonmouth/html.py
+++ b/cottonmouth/html.py
@@ -86,16 +86,20 @@ def render_tag(tag, content, **context):
     if u'#' in chunks[0]:
         tag, extra['id'] = chunks[0].split('#')
 
-    # Format classes
+    # Parse classes
     classes = chunks[1:]
-    dynamic_class = extra.get('class')
-    if classes and dynamic_class:
-        raise ValueError(CLASS_NAME_COLLISION_MESSAGE)
-    elif classes:
-        extra['class'] = ' '.join(classes)
+    extra_classes = extra.get('class')
+    if isinstance(extra_classes, basestring):
+        classes.extend(extra_classes.split())
+    elif extra_classes:
+        classes.extend(extra_classes)
+
+    # Format classes
+    if classes:
+        extra['class'] = u' '.join(classes)
 
     # Format attributes
-    attributes = ''.join([u' {}="{}"'.format(*i) for i in extra.items()])
+    attributes = u''.join([u' {}="{}"'.format(*i) for i in extra.items()])
 
     # Start our tag sandwich
     yield u'<{}{}>'.format(tag, attributes)

--- a/cottonmouth/html.py
+++ b/cottonmouth/html.py
@@ -3,6 +3,9 @@ import itertools
 
 from . import constants
 
+CLASS_NAME_COLLISION_MESSAGE = \
+    u'Class names must be set in the tag or the attribute, not both.'
+
 
 def render(*content, **context):
     """
@@ -84,9 +87,11 @@ def render_tag(tag, content, **context):
         tag, extra['id'] = chunks[0].split('#')
 
     # Format classes
-    classes = extra.get('class', [])
-    classes.extend(chunks[1:])
-    if classes:
+    classes = chunks[1:]
+    dynamic_class = extra.get('class')
+    if classes and dynamic_class:
+        raise ValueError(CLASS_NAME_COLLISION_MESSAGE)
+    elif classes:
         extra['class'] = ' '.join(classes)
 
     # Format attributes

--- a/tests.py
+++ b/tests.py
@@ -15,6 +15,12 @@ class TestHTML(unittest.TestCase):
             '<div id="my" class="test">testing</div>'
         )
 
+    def test_div_shortcut_with_classname(self):
+        self.assertEqual(
+            render(['.test', 'testing']),
+            '<div class="test">testing</div>'
+        )
+
     def test_image(self):
         self.assertEqual(
             render(['img', {'src': 'image.png'}]),

--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,7 @@ import unittest
 
 from cottonmouth import constants
 from cottonmouth import tags
-from cottonmouth.html import render
+from cottonmouth.html import render, CLASS_NAME_COLLISION_MESSAGE
 
 
 class TestHTML(unittest.TestCase):
@@ -93,6 +93,23 @@ class TestHTML(unittest.TestCase):
         self.assertEqual(
             render(content),
             u'<p>{}</p>'.format(unicode(object_))
+        )
+
+    def test_class_name_can_be_set_via_attributes(self):
+        content = ['span', {'class': 'foo'}, 'hello']
+        self.assertEqual(
+            render(content),
+            u'<span class="foo">hello</span>'
+        )
+
+    def test_class_names_can_be_extended_via_attributes(self):
+        content = ['span.foo', {'class': 'bar'}, 'hello']
+        with self.assertRaises(ValueError) as context:
+            render(content)
+
+        self.assertEqual(
+            unicode(context.exception),
+            CLASS_NAME_COLLISION_MESSAGE
         )
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -95,22 +95,30 @@ class TestHTML(unittest.TestCase):
             u'<p>{}</p>'.format(unicode(object_))
         )
 
-    def test_class_name_can_be_set_via_attributes(self):
+    def test_class_name_are_set_via_attributes(self):
         content = ['span', {'class': 'foo'}, 'hello']
         self.assertEqual(
             render(content),
             u'<span class="foo">hello</span>'
         )
 
-    def test_class_names_can_be_extended_via_string_attribute(self):
+    def test_class_names_are_extended_via_string_attribute(self):
         content = ['span.foo', {'class': 'bar'}, 'hello']
         self.assertEqual(
             render(content),
             u'<span class="foo bar">hello</span>'
         )
 
-    def test_class_names_can_be_extended_via_list_attribute(self):
+    def test_class_names_are_extended_via_list_attribute(self):
         content = ['span.foo', {'class': ['bar', 'baz']}, 'hello']
+        self.assertEqual(
+            render(content),
+            u'<span class="foo bar baz">hello</span>'
+        )
+
+    def test_class_names_are_extended_via_iterable_attribute(self):
+        classes = (_ for _ in ['bar', 'baz'])
+        content = ['span.foo', {'class': classes}, 'hello']
         self.assertEqual(
             render(content),
             u'<span class="foo bar baz">hello</span>'

--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,7 @@ import unittest
 
 from cottonmouth import constants
 from cottonmouth import tags
-from cottonmouth.html import render, CLASS_NAME_COLLISION_MESSAGE
+from cottonmouth.html import render
 
 
 class TestHTML(unittest.TestCase):
@@ -102,15 +102,20 @@ class TestHTML(unittest.TestCase):
             u'<span class="foo">hello</span>'
         )
 
-    def test_class_names_can_be_extended_via_attributes(self):
+    def test_class_names_can_be_extended_via_string_attribute(self):
         content = ['span.foo', {'class': 'bar'}, 'hello']
-        with self.assertRaises(ValueError) as context:
-            render(content)
-
         self.assertEqual(
-            unicode(context.exception),
-            CLASS_NAME_COLLISION_MESSAGE
+            render(content),
+            u'<span class="foo bar">hello</span>'
         )
+
+    def test_class_names_can_be_extended_via_list_attribute(self):
+        content = ['span.foo', {'class': ['bar', 'baz']}, 'hello']
+        self.assertEqual(
+            render(content),
+            u'<span class="foo bar baz">hello</span>'
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Rendering was crashing when a string was passed in the extra `class` attribute. Passing a string is a perfectly reasonable thing to do and is supported by Hiccup, so now it works here too.

The assumption I originally made was that the explicit class defined by `tag.className` would be an invariant, and class would be an optional list of additional classnames passed in the the attributes that would be appended to the invariant classnames. This is now officially documented and tested, with additional support for string-encoded classnames.

Incidental cleanup: the sugar for rendering `.foo` as a div element was not implemented and was necessary for clear documentation.

Closes #1.