### PR TITLE
Support style tags

### DIFF
--- a/cottonmouth/constants.py
+++ b/cottonmouth/constants.py
@@ -7,7 +7,6 @@ HTML_VOID_TAGS = [
     'embed',
     'hr',
     'img',
-    'input',
     'keygen',
     'link',
     'meta',

--- a/cottonmouth/html.py
+++ b/cottonmouth/html.py
@@ -66,7 +66,7 @@ def render_attribute(key, value):
             # map bool to "true"/"false"
             bool: lambda x: str(x).lower(),
             # treat attribute dicts as style
-            dict: lambda x: '; '.join(f'{k}: {v}' for k,v in x.items()),
+            dict: lambda x: ' '.join(f'{k}: {v};' for k,v in x.items()),
         }.get(type(value), lambda x: f'{x}')(value)
 
     return f'{key}="{map_value_type(value)}"'

--- a/cottonmouth/html.py
+++ b/cottonmouth/html.py
@@ -55,6 +55,20 @@ def render_iterable(content, **context):
             for e in render_content(content, **context):
                 yield e
 
+def render_attribute(key, value):
+    """
+    Renders a tag attribute key/value pair.
+    """
+    # map from type(value) -> fn(type(value)) -> str
+    # by default, cast to string and wrap in quotes
+    def map_value_type(value):
+        return {
+            # map bool to "true"/"false"
+            bool: lambda x: str(x).lower()
+        }.get(type(value), lambda x: f'{x}')(value)
+
+    return f'{key}="{map_value_type(value)}"'
+
 def render_tag(tag, content, **context):
     """
     Renders an HTML tag with its content.
@@ -97,7 +111,7 @@ def render_tag(tag, content, **context):
         extra['class'] = ' '.join(classes)
 
     # Format attributes
-    attributes = [f'{k}="{v}"' for k,v in extra.items()]
+    attributes = [render_attribute(k,v) for k,v in extra.items()]
     tag_contents = ' '.join([tag] + attributes)
 
     # Start our tag sandwich

--- a/cottonmouth/html.py
+++ b/cottonmouth/html.py
@@ -64,7 +64,9 @@ def render_attribute(key, value):
     def map_value_type(value):
         return {
             # map bool to "true"/"false"
-            bool: lambda x: str(x).lower()
+            bool: lambda x: str(x).lower(),
+            # treat attribute dicts as style
+            dict: lambda x: '; '.join(f'{k}: {v}' for k,v in x.items()),
         }.get(type(value), lambda x: f'{x}')(value)
 
     return f'{key}="{map_value_type(value)}"'

--- a/cottonmouth/html.py
+++ b/cottonmouth/html.py
@@ -8,10 +8,7 @@ def render(*content, **context):
     """
     Renders a sequence of content as HTML.
     """
-    return ''.join(
-        e for c in content
-        for e in render_content(c, **context)
-    )
+    return ''.join(e for c in content for e in render_content(c, **context))
 
 
 def render_content(content, **context):
@@ -58,7 +55,6 @@ def render_iterable(content, **context):
             for e in render_content(content, **context):
                 yield e
 
-
 def render_tag(tag, content, **context):
     """
     Renders an HTML tag with its content.
@@ -76,9 +72,9 @@ def render_tag(tag, content, **context):
 
     # Default to div if no explicit tag is provided
     if tag.startswith('#'):
-        tag = 'div{}'.format(tag)
+        tag = f'div{tag}'
     elif tag.startswith('.'):
-        tag = 'div{}'.format(tag)
+        tag = f'div{tag}'
 
     # Split tag into ["tag#id", "class1", "class2", ...] chunks
     chunks = tag.split('.')
@@ -101,10 +97,11 @@ def render_tag(tag, content, **context):
         extra['class'] = ' '.join(classes)
 
     # Format attributes
-    attributes = ''.join([' {}="{}"'.format(*i) for i in extra.items()])
+    attributes = [f'{k}="{v}"' for k,v in extra.items()]
+    tag_contents = ' '.join([tag] + attributes)
 
     # Start our tag sandwich
-    yield '<{}{}>'.format(tag, attributes)
+    yield f'<{tag_contents}>'
 
     # Render the delicious filling or toppings
     for content in remainder:
@@ -113,4 +110,4 @@ def render_tag(tag, content, **context):
 
     # CLOSE THE TAG IF WE HAVE TO I GUESS
     if tag not in constants.HTML_VOID_TAGS:
-        yield '</{}>'.format(tag)
+        yield f'</{tag}>'

--- a/tests.py
+++ b/tests.py
@@ -144,5 +144,12 @@ class TestHTML(unittest.TestCase):
             '<input type="checkbox" checked="true"></input>'
         )
 
+    def test_attribute_dicts_as_style_tags(self):
+        content = ['div', {'style': {'visibility': 'hidden'}}]
+        self.assertEqual(
+            render(content),
+            '<div style="visibility: hidden"></div>'
+        )
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -130,6 +130,12 @@ class TestHTML(unittest.TestCase):
             '<span class="foo bar baz">hello</span>'
         )
 
+    def test_input_tag_closed(self):
+        content = ['input', {'type': 'text'}, 'hello']
+        self.assertEqual(
+            render(content),
+            '<input type="text">hello</input>'
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -137,5 +137,12 @@ class TestHTML(unittest.TestCase):
             '<input type="text">hello</input>'
         )
 
+    def test_input_tag_checked(self):
+        content = ['input', {'type': 'checkbox', 'checked': True}]
+        self.assertEqual(
+            render(content),
+            '<input type="checkbox" checked="true"></input>'
+        )
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -148,7 +148,7 @@ class TestHTML(unittest.TestCase):
         content = ['div', {'style': {'visibility': 'hidden'}}]
         self.assertEqual(
             render(content),
-            '<div style="visibility: hidden"></div>'
+            '<div style="visibility: hidden;"></div>'
         )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Note: This PR uses #11 as the base, and as such, #11 should be merged first.

This adds support for attribute dicts of dicts.
They are assumed to be style tags.
Hiccup appears to do the same: https://github.com/weavejester/hiccup/issues/159